### PR TITLE
Fix session initialization in personalizar.php

### DIFF
--- a/admin/personalizar.php
+++ b/admin/personalizar.php
@@ -1,20 +1,4 @@
 <?php
-session_start();
-if (!isset($user) && isset($_SESSION['user'])) {
-    $user = $_SESSION['user'];
-}
-if (!isset($_SESSION['user_id']) && isset($user['id'])) {
-    $_SESSION['user_id'] = $user['id'];
-}
-?>
-<?php<?php
-session_start();
-if (!isset($_SESSION['user_id']) && isset($user['id'])) {
-    $_SESSION['user_id'] = $user['id'];
-}
-?>
- session_start(); $_SESSION['user_id'] = $user['id']; ?>
-<?php
 require_once 'includes/auth.php';
 require_once 'includes/header.php';
 


### PR DESCRIPTION
## Summary
- remove duplicate PHP opening blocks and redundant `session_start()` calls in `admin/personalizar.php`

## Testing
- `php -l admin/personalizar.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68643984e8d48332aaeea885dadbd045