### PR TITLE
Fix session start logic

### DIFF
--- a/admin/includes/auth.php
+++ b/admin/includes/auth.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 if (!isset($_SESSION['user'])) {
     header("Location: login.php");


### PR DESCRIPTION
## Summary
- prevent double session starting

## Testing
- `php -l admin/includes/auth.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686439860bd883329876c092c4c2238c