### PR TITLE
Fix setup wizard

### DIFF
--- a/admin/check_email.php
+++ b/admin/check_email.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/includes/db.php';
+header('Content-Type: application/json');
+$email = $_POST['email'] ?? '';
+if (!$email) {
+    echo json_encode(['exists' => false]);
+    exit;
+}
+$stmt = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+$stmt->execute([$email]);
+$exists = $stmt->fetchColumn() ? true : false;
+echo json_encode(['exists' => $exists]);
+

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,40 +1,3 @@
-<?php if ($estado_cuenta === 0): ?>
-<style>
-    body {
-        overflow: hidden;
-    }
-    .blur-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        backdrop-filter: blur(4px);
-        background-color: rgba(0, 0, 0, 0.3);
-        z-index: 9998;
-    }
-    .modal-block {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        background: white;
-        padding: 30px;
-        border-radius: 10px;
-        box-shadow: 0 0 20px rgba(0,0,0,0.25);
-        z-index: 9999;
-        max-width: 90%;
-        width: 400px;
-        text-align: center;
-        font-family: 'Poppins', sans-serif;
-    }
-    .modal-block h2 {
-        margin-top: 0;
-        color: #e74c3c;
-    }
-</style>
-<?php endif; ?>
-
 <?php
 require_once 'includes/auth.php';
 
@@ -51,8 +14,11 @@ $plan_cuenta = $datos_cuenta['plan'] ?? 'No especificado';
 $desde_cuenta = $datos_cuenta['desde'] ?? '—';
 $hasta_cuenta = $datos_cuenta['hasta'] ?? '—';
 ?>
-<?php if (intval($estado_cuenta) === 0): ?>
+<?php if ($estado_cuenta === 0): ?>
 <style>
+    body {
+        overflow: hidden;
+    }
     .blur-overlay {
         position: fixed;
         top: 0;
@@ -89,23 +55,8 @@ $hasta_cuenta = $datos_cuenta['hasta'] ?? '—';
     <p>La cuenta se encuentra suspendida, por favor contactarse con Administración de <strong>SoloSellos.com</strong></p>
 </div>
 <?php endif; ?>
-<?php
-require_once 'includes/auth.php';
 
-if (!isset($pdo)) {
-    require_once 'includes/db.php';
-}
-
-// Verificar estado actual desde la base de datos
-$stmt = $pdo->prepare("SELECT plan, desde, hasta, active FROM users WHERE id = ?");
-$stmt->execute([$_SESSION['user']['id']]);
-$datos_cuenta = $stmt->fetch(PDO::FETCH_ASSOC);
-$estado_cuenta = $datos_cuenta['active'];
-$plan_cuenta = $datos_cuenta['plan'] ?? 'No especificado';
-$desde_cuenta = $datos_cuenta['desde'] ?? '—';
-$hasta_cuenta = $datos_cuenta['hasta'] ?? '—';
-
-require_once 'includes/header.php';
+<?php require_once 'includes/header.php';
 
 // ID del usuario logueado
 $user_id = $_SESSION['user']['id'];

--- a/admin/formreg.html
+++ b/admin/formreg.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Registro de nuevo Cliente</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
     :root {
       --primary-color: #009ee3;
@@ -27,6 +28,77 @@
       align-items: center;
       min-height: 100vh;
       padding: 20px;
+      position: relative;
+    }
+
+    .avatar-box {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+    }
+    .avatar-box i {
+      font-size: 30px;
+      color: var(--primary-color);
+      cursor: pointer;
+    }
+    .login-dropdown {
+      display: none;
+      position: absolute;
+      top: 36px;
+      right: 0;
+      background: #fff;
+      padding: 15px;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      width: 220px;
+      z-index: 100;
+    }
+    .login-dropdown.show {
+      display: block;
+    }
+    .login-dropdown input {
+      width: 100%;
+      margin-bottom: 10px;
+      padding: 8px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      font-size: 14px;
+    }
+    .login-dropdown button {
+      width: 100%;
+      padding: 8px;
+      background: var(--primary-color);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .login-dropdown button:hover {
+      background: var(--primary-dark);
+    }
+
+    .modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity .3s ease;
+      z-index: 200;
+    }
+    .modal.show {
+      opacity: 1;
+      visibility: visible;
+    }
+    .modal-content {
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      text-align: center;
+      max-width: 300px;
     }
 
     .form-container {
@@ -57,6 +129,16 @@
       border: 1px solid #ccc;
       border-radius: 6px;
       font-size: 16px;
+    }
+    .email-field {
+      position: relative;
+    }
+    #emailStatus {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 18px;
     }
 
     button {
@@ -90,8 +172,19 @@
       }
     }
   </style>
+
 </head>
 <body>
+  <div class="avatar-box">
+    <i id="avatarIcon" class="fas fa-user-circle"></i>
+    <div id="loginDropdown" class="login-dropdown">
+      <form action="login.php" method="POST">
+        <input type="email" name="email" placeholder="Correo" required>
+        <input type="password" name="password" placeholder="Contraseña" required>
+        <button type="submit">Ingresar</button>
+      </form>
+    </div>
+  </div>
 
   <form class="form-container" action="registro_desde_wp.php" method="POST">
     <h2>Crear cuenta gratuita</h2>
@@ -100,7 +193,10 @@
     <input type="text" id="nombre" name="nombre" required>
 
     <label for="email">Correo electrónico</label>
-    <input type="email" id="email" name="email" required>
+    <div class="email-field">
+      <input type="email" id="email" name="email" required>
+      <span id="emailStatus"></span>
+    </div>
 
     <label for="telefono">Número de WhatsApp</label>
     <input type="text" id="telefono" name="telefono" required>
@@ -110,6 +206,62 @@
 
     <button type="submit">Probar el sistema gratis</button>
   </form>
+
+  <div id="errorModal" class="modal">
+    <div class="modal-content">
+      <p>El correo ya se encuentra registrado.</p>
+      <button id="closeModal" type="button">Cerrar</button>
+    </div>
+  </div>
+
+  <script>
+    const avatar = document.getElementById('avatarIcon');
+    const dropdown = document.getElementById('loginDropdown');
+    avatar.addEventListener('click', e => {
+      e.stopPropagation();
+      dropdown.classList.toggle('show');
+    });
+    document.addEventListener('click', e => {
+      if (!dropdown.contains(e.target)) {
+        dropdown.classList.remove('show');
+      }
+    });
+
+    const emailInput = document.getElementById('email');
+    const emailStatus = document.getElementById('emailStatus');
+    let emailTimer;
+    emailInput.addEventListener('input', () => {
+      clearTimeout(emailTimer);
+      emailStatus.textContent = '';
+      const val = emailInput.value.trim();
+      if (!val) return;
+      emailTimer = setTimeout(() => {
+        const data = new URLSearchParams();
+        data.append('email', val);
+        fetch('check_email.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: data.toString()
+        }).then(r => r.json())
+          .then(d => {
+            if (d.exists) {
+              emailStatus.textContent = '❌';
+              emailStatus.style.color = 'red';
+            } else {
+              emailStatus.textContent = '✔️';
+              emailStatus.style.color = 'green';
+            }
+          });
+      }, 400);
+    });
+
+    const modal = document.getElementById('errorModal');
+    const closeBtn = document.getElementById('closeModal');
+    closeBtn.addEventListener('click', () => modal.classList.remove('show'));
+    if (window.location.search.includes('error=exists')) {
+      modal.classList.add('show');
+    }
+  </script>
 
 </body>
 </html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -14,7 +14,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     if ($user && hash('sha256', $pass) === $user['password']) {
         $_SESSION['user'] = $user;
-        header("Location: dashboard.php");
+        $needs_setup = empty($user['name']) || empty($user['color_primary']);
+        if ($needs_setup) {
+            header("Location: setup_wizard.php");
+        } else {
+            header("Location: dashboard.php");
+        }
         exit;
     } else {
         $error = "Credenciales inválidas";

--- a/admin/pedidos.php
+++ b/admin/pedidos.php
@@ -68,7 +68,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['pedido_id'], $_POST['
     transform: scale(0.5);
     transform-origin: top left;
     width: 420px;
-    height: 160px;
+    height: 180px;
     background: black;
     border: 1px dashed #aaa;
     display: flex;
@@ -81,11 +81,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['pedido_id'], $_POST['
 }
 .linea-prev {
     width: 100%;
+    margin-bottom: 5px;
 }
 
 .preview-wrapper {
     width: 190px;
-    height: 70px;
+    height: 80px;
     overflow: hidden;
     justify-content: center;
     align-items: center;
@@ -219,7 +220,7 @@ function cerrarSidebar() {
             <td>
                 <div class="preview-wrapper" style="position:relative;">
                 <div style="width: 380px; aspect-ratio: 1.875;">
-                <div style="justify-content: center; align-items: center; transform: scale(0.5); transform-origin: top left; width: 380px; height: 140px; background: black; position: relative; padding-top: 5px;">
+                <div style="justify-content: center; align-items: center; transform: scale(0.5); transform-origin: top left; width: 380px; height: 160px; background: black; position: relative; padding-top: 5px;">
                     <?php
                     $styles = json_decode($order['styles'], true);
                     for ($i = 1; $i <= 4; $i++) {
@@ -234,6 +235,7 @@ function cerrarSidebar() {
                         echo 'font-weight:' . $bold . ';';
                         echo 'color:white;';
                         echo 'margin-top:' . $top . 'px;';
+                        echo 'margin-bottom:5px;';
                         echo 'text-align:center;';
                         echo 'width:100%;';
                         echo '">' . $line . '</div>';
@@ -242,7 +244,7 @@ function cerrarSidebar() {
                 </div>
                 </div>
 
-                <div class="preview" id="preview-<?= $order['id'] ?>" style="width: 380px; height: 140px; background: black; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center;">
+                <div class="preview" id="preview-<?= $order['id'] ?>" style="width: 380px; height: 160px; background: black; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center;">
                     <?php for ($i = 1; $i <= 4; $i++): ?>
                         <?php
                             $text = htmlspecialchars($order["text_line$i"]);
@@ -257,11 +259,11 @@ function cerrarSidebar() {
                         ?>
                         <div class="linea-prev" style="
                             margin-top: <?= $margin_top ?>px;
+                            margin-bottom: 5px;
                             font-family: '<?= $font ?>', sans-serif;
                             font-size: <?= $size ?>px;
                             font-weight: <?= $bold ?>;
                             text-align: <?= $align ?>;
-                            line-height: <?= $size * 1.1 ?>px;
                             width: 380px;
                             color: white;
                         "><?= $text ?></div>

--- a/admin/plantillas.php
+++ b/admin/plantillas.php
@@ -109,7 +109,7 @@ $categorias = $cats->fetchAll();
 }
 .preview {
     width: 238px;
-    height: 126px;
+    height: 136px;
     border: 1px dashed #aaa;
     background-color: #eee;
     position: relative;
@@ -179,7 +179,7 @@ $categorias = $cats->fetchAll();
       <?php if ($plantilla['category_id'] == $cat['id']): ?>
       <div class="card">
         
-<div class="preview" style="margin: 0 auto; width: 380px; height: 140px; border: 2px dashed #aaa; background-color: #fff; overflow: hidden; transform: scale(0.6); transform-origin: top left; display: flex; flex-direction: column; justify-content: center;">
+<div class="preview" style="margin: 0 auto; width: 380px; height: 160px; border: 2px dashed #aaa; background-color: #fff; overflow: hidden; transform: scale(0.6); transform-origin: top left; display: flex; flex-direction: column; justify-content: center; align-items: center;">
   <?php $contenido = json_decode($plantilla["content"], true); ?>
   <?php for ($i = 1; $i <= 4; $i++):
     $texto = $contenido["linea$i"] ?? "";
@@ -195,6 +195,7 @@ $categorias = $cats->fetchAll();
       font-weight: <?= $bold ?>;
       text-align: <?= $alineacion ?>;
       margin-top: <?= $margen ?>px;
+      margin-bottom: 5px;
       white-space: nowrap;
       color: black;
       width: 100%;

--- a/admin/registro_desde_wp.php
+++ b/admin/registro_desde_wp.php
@@ -22,7 +22,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $verificar->store_result();
 
     if ($verificar->num_rows > 0) {
-        die("Ya existe un usuario registrado con ese correo.");
+        header('Location: formreg.html?error=exists');
+        exit;
     }
     $verificar->close();
 

--- a/admin/setup_wizard.php
+++ b/admin/setup_wizard.php
@@ -1,0 +1,175 @@
+<?php
+require_once 'includes/auth.php';
+require_once 'includes/header.php';
+
+$already_configured = !empty($_SESSION['user']['name']) && !empty($_SESSION['user']['color_primary']);
+$force = isset($_GET['force']) && $_GET['force'] === '1';
+if ($already_configured && !$force) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'] ?? '';
+    $whatsapp = $_POST['whatsapp'] ?? '';
+    $email = $_POST['email'] ?? '';
+    $color_primary = $_POST['color_primary'] ?? '#1abc9c';
+    $color_secundary = $_POST['color_secundary'] ?? '#16a085';
+    $background_image = $_POST['background_image'] ?? '';
+    $welcome = $_POST['welcome'] ?? '';
+    $footer = $_POST['footer'] ?? '';
+    $logo = $_SESSION['user']['logo'] ?? '';
+
+    if (!empty($_FILES['logo']['name'])) {
+        $logo = basename($_FILES['logo']['name']);
+        move_uploaded_file($_FILES['logo']['tmp_name'], '../assets/images/' . $logo);
+    }
+
+    $stmt = $pdo->prepare("UPDATE users SET name=?, whatsapp=?, email=?, color_primary=?, color_secundary=?, background_image=?, welcome=?, footer=?, logo=? WHERE id=?");
+    $stmt->execute([$name, $whatsapp, $email, $color_primary, $color_secundary, $background_image, $welcome, $footer, $logo, $_SESSION['user']['id']]);
+
+    $_SESSION['user'] = array_merge($_SESSION['user'], [
+        'name' => $name,
+        'whatsapp' => $whatsapp,
+        'email' => $email,
+        'color_primary' => $color_primary,
+        'color_secundary' => $color_secundary,
+        'background_image' => $background_image,
+        'welcome' => $welcome,
+        'footer' => $footer,
+        'logo' => $logo
+    ]);
+
+    header('Location: dashboard.php');
+    exit;
+} else {
+    $name = $_SESSION['user']['name'] ?? '';
+    $whatsapp = $_SESSION['user']['whatsapp'] ?? '';
+    $email = $_SESSION['user']['email'] ?? '';
+    $color_primary = $_SESSION['user']['color_primary'] ?? '#1abc9c';
+    $color_secundary = $_SESSION['user']['color_secundary'] ?? '#16a085';
+    $background_image = $_SESSION['user']['background_image'] ?? '';
+    $welcome = $_SESSION['user']['welcome'] ?? '';
+    $footer = $_SESSION['user']['footer'] ?? '';
+    $logo = $_SESSION['user']['logo'] ?? '';
+}
+?>
+<h2>Asistente de Configuración</h2>
+<form method="POST" enctype="multipart/form-data" id="wizardForm">
+<div id="wizard" style="display:flex;gap:40px;">
+  <div class="steps" style="width:40%;max-width:350px;">
+    <div class="step active" data-step="1">
+        <h3>Paso 1</h3>
+        <label>Nombre de tu negocio</label>
+        <input type="text" name="name" id="bizname" value="<?= htmlspecialchars($name) ?>" required>
+        <label>Logo</label>
+        <input type="file" name="logo" id="logoInput">
+    </div>
+    <div class="step" data-step="2">
+        <h3>Paso 2</h3>
+        <label>Número de WhatsApp</label>
+        <input type="text" name="whatsapp" id="whatsapp" value="<?= htmlspecialchars($whatsapp) ?>">
+        <label>Email de notificaciones</label>
+        <input type="email" name="email" id="email" value="<?= htmlspecialchars($email) ?>">
+    </div>
+    <div class="step" data-step="3">
+        <h3>Paso 3</h3>
+        <label>Color primario</label>
+        <input type="color" name="color_primary" id="color_primary" value="<?= htmlspecialchars($color_primary) ?>">
+        <label>Color secundario</label>
+        <input type="color" name="color_secundary" id="color_secundary" value="<?= htmlspecialchars($color_secundary) ?>">
+        <input type="hidden" name="background_image" id="background_image" value="<?= htmlspecialchars($background_image) ?>">
+        <p>Imagen de fondo:</p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,80px);gap:10px;">
+        <?php
+          $fondos = glob('../assets/images/bg/*.jpg');
+          foreach ($fondos as $f) {
+            $n = basename($f);
+            $checked = $n === $background_image ? 'checked' : '';
+            echo "<label style=\"width:80px;height:80px;cursor:pointer;background-size:cover;background-image:url('../assets/images/bg/$n');display:inline-block;position:relative;border:2px solid transparent;\">";
+            echo "<input type='radio' name='bg_select' value='$n' style='position:absolute;top:5px;left:5px;' $checked>";
+            echo "</label>";
+          }
+        ?>
+        </div>
+    </div>
+    <div class="step" data-step="4">
+        <h3>Paso 4</h3>
+        <label>Mensaje de bienvenida</label>
+        <textarea name="welcome" id="welcome" rows="2"><?= htmlspecialchars($welcome) ?></textarea>
+        <label>Footer</label>
+        <textarea name="footer" id="footer" rows="2"><?= htmlspecialchars($footer) ?></textarea>
+    </div>
+    <div style="margin-top:20px;">
+      <button type="button" id="prevBtn" style="display:none;">Anterior</button>
+      <button type="button" id="nextBtn">Siguiente</button>
+      <button type="submit" id="finishBtn" style="display:none;">Guardar</button>
+    </div>
+  </div>
+  <div style="flex:1;border:1px solid #ccc;border-radius:8px;overflow:hidden;">
+      <iframe id="previewFrame" src="../public/index.php?u=<?= urlencode($_SESSION['user']['link_code']) ?>" style="width:100%;height:600px;border:0;"></iframe>
+  </div>
+</div>
+</form>
+
+<style>
+.step{display:none;}
+.step.active{display:block;animation:fadeIn 0.3s ease;}
+@keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+</style>
+
+<script>
+const steps = document.querySelectorAll('.step');
+let current = 0;
+const prevBtn = document.getElementById('prevBtn');
+const nextBtn = document.getElementById('nextBtn');
+const finishBtn = document.getElementById('finishBtn');
+function showStep(i){
+  steps[current].classList.remove('active');
+  current=i;
+  steps[current].classList.add('active');
+  prevBtn.style.display = current===0? 'none':'inline-block';
+  nextBtn.style.display = current===steps.length-1? 'none':'inline-block';
+  finishBtn.style.display = current===steps.length-1? 'inline-block':'none';
+}
+prevBtn.addEventListener('click',()=>{ if(current>0) showStep(current-1); });
+nextBtn.addEventListener('click',()=>{ if(current<steps.length-1) showStep(current+1); });
+showStep(0);
+
+const iframe = document.getElementById('previewFrame');
+let previewDoc = null;
+iframe.addEventListener('load', () => { previewDoc = iframe.contentWindow.document; updatePreview(); });
+
+function updatePreview(){
+  if(!previewDoc) return;
+  const name = document.getElementById('bizname').value || 'Tu negocio';
+  const welcome = document.getElementById('welcome').value;
+  const footer = document.getElementById('footer').value;
+  const colorP = document.getElementById('color_primary').value;
+  const colorS = document.getElementById('color_secundary').value;
+  const bg = document.getElementById('background_image').value;
+
+  const logoInput = document.getElementById('logoInput');
+  const logoFile = logoInput.files[0];
+  const logoSrc = logoFile ? URL.createObjectURL(logoFile) : previewDoc.querySelector('header img')?.src;
+
+  const headerImg = previewDoc.querySelector('header img');
+  if (headerImg && logoSrc) headerImg.src = logoSrc;
+  const nameEl = previewDoc.querySelector('header span');
+  if (nameEl) nameEl.textContent = name;
+
+  previewDoc.documentElement.style.setProperty('--color-principal', colorP);
+  previewDoc.documentElement.style.setProperty('--color-secundario', colorS);
+  if (bg) previewDoc.body.style.backgroundImage = "url('../assets/images/bg/"+bg+"')";
+
+  const welcomeEl = previewDoc.querySelector('.bienvenida div');
+  if (welcomeEl) welcomeEl.textContent = welcome;
+  const footerEl = previewDoc.querySelector('footer');
+  if (footerEl) footerEl.innerHTML = footer;
+}
+
+document.querySelectorAll('#bizname,#welcome,#footer,#color_primary,#color_secundary').forEach(el=>el.addEventListener('input',updatePreview));
+document.querySelectorAll("input[name='bg_select']").forEach(el=>el.addEventListener('change',()=>{document.getElementById('background_image').value=el.value;updatePreview();}));
+document.getElementById('logoInput').addEventListener('change',updatePreview);
+</script>
+<?php require_once 'includes/footer.php'; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,4 @@
 <?php
-require_once '../config.php';
 require_once '../admin/includes/db.php';
 
 if (!isset($_GET['u'])) {
@@ -279,7 +278,7 @@ $models = $stmt->fetchAll();
       <label class="modelo-card" style="display:block; border-radius: 8px; padding:10px; width: 200px;  background: #fff; margin-bottom: 10px;" style="zoom: 0.5; transform-origin: top left; box-shadow: 0 4px 12px rgba(0,0,0,0.15); width: 48%; margin: 1%; float: left; background: #fff; border-radius: 8px; padding: 10px;">
         <input type="radio" name="template_id" value="<?= $plantilla['id'] ?>" required style="display:none;">
         <div>
-          <div class="preview" style="width: 340px; height: 180px; zoom: 0.5; transform-origin: top left; display: flex; flex-direction: column; justify-content: space-around; align-items: center; background: white; border: 1px dashed #ccc; margin: 0 auto;  width: 380px; height: auto; background-color: #fff; padding-top: 0; overflow: hidden; zoom: 0.5; transform-origin: top left; display: flex; flex-direction: column; justify-content: center; align-items: center; line-height: 1.1; overflow: hidden; display: flex; flex-direction: column; justify-content: space-evenly; align-items: center; gap: 0.2em; display: flex; flex-direction: column; align-items: center; margin-top: auto; margin-bottom: auto; gap: 0.3em; display: flex; flex-direction: column; align-items: center; margin-top: auto; margin-bottom: auto; gap: 0.3em; padding-top: 10px; padding-bottom: 10px;">
+          <div class="preview" style="width: 380px; height: 180px; zoom: 0.5; transform-origin: top left; display: flex; flex-direction: column; justify-content: center; align-items: center; background: white; border: 1px dashed #ccc; margin: 0 auto; overflow: hidden; padding-top: 10px; padding-bottom: 10px;">
             <?php for ($i = 1; $i <= 4; $i++):
               $texto = $contenido["linea$i"] ?? "";
               $fuente = $plantilla["fuente_linea_$i"] ?? 'Arial';
@@ -294,6 +293,7 @@ $models = $stmt->fetchAll();
                 font-weight: <?= $bold ?>;
                 text-align: <?= $alineacion ?>;
                 margin-top: <?= $margen ?>px;
+                margin-bottom: 5px;
                 white-space: nowrap;
                 color: black;
                 width: 100%;

--- a/public/thanks.php
+++ b/public/thanks.php
@@ -1,15 +1,5 @@
 
 <?php
-$estado = $order['estado'];
-$badgeClass = match($estado) {
-    'Recibido' => 'badge-gray',
-    'Confirmado' => 'badge-blue',
-    'En Producción' => 'badge-yellow',
-    'Cancelado' => 'badge-red',
-    'Entregado' => 'badge-green',
-    default => 'badge-gray'
-};
-
 require_once '../admin/includes/db.php';
 
 $order_code = $_GET['order'] ?? null;
@@ -50,6 +40,16 @@ if (!$order) {
     echo "Pedido no encontrado.";
     exit;
 }
+
+$estado = $order['status'] ?? '';
+$badgeClass = match($estado) {
+    'Recibido' => 'badge-gray',
+    'Confirmado' => 'badge-blue',
+    'En Producción' => 'badge-yellow',
+    'Cancelado' => 'badge-red',
+    'Entregado' => 'badge-green',
+    default => 'badge-gray'
+};
 
 $color = $order['color'] ?? '#009688';
 
@@ -194,13 +194,17 @@ header {
   margin-bottom: 25px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.06);
 }
-        .preview {
-            transform: scale(0.8);
-            transform-origin: top center;
-        }
+.preview {
+    transform: scale(0.8);
+    transform-origin: top center;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+}
         .linea-prev {
             white-space: nowrap;
             width: 100%;
+            margin-bottom: 5px;
         }
         .modelo img {
             width: 100%;
@@ -307,6 +311,7 @@ header {
                         font-weight: <?= $bold ?>;
                         text-align: <?= $align ?>;
                         margin-top: <?= $margen ?>px;
+                        margin-bottom: 5px;
                     "><?= $text ?></div>
                 <?php endfor; ?>
             </div>


### PR DESCRIPTION
## Summary
- remove references to nonexistent `setup_complete` DB column
- trigger the wizard based on missing profile data instead
- prefill wizard fields with existing user data and show real site in an iframe preview
- allow rerunning the wizard manually via `setup_wizard.php?force=1`
- added button in personalization page to access the wizard

## Testing
- `php -l admin/personalizar.php` *(fails: `php` not found)*
- `php -l admin/setup_wizard.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643984e8d48332aaeea885dadbd045