### PR TITLE
Auto login after successful MercadoPago subscription

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -189,7 +189,17 @@ if (isset($_GET['preapproval_id'])) {
     if (isset($data['status']) && $data['status'] === 'authorized') {
         $referencia = $data['external_reference'];
         $user_id = str_replace("usuario_", "", $referencia);
-        $conn->query("UPDATE users SET active = 1, plan = 'mensual' WHERE id = $user_id");
+        $conn->query("UPDATE users SET active = 1, plan = 'mensual', preapproval_id = '$preapproval_id' WHERE id = $user_id");
+
+        $stmt = $pdo->prepare("SELECT * FROM users WHERE id = ?");
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($user) {
+            $_SESSION['user'] = $user;
+            header("Location: setup_wizard.php");
+            exit;
+        }
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- automatically log in the user when returning from MercadoPago
- update login.php to fetch the user, store it in session and redirect to the setup wizard

## Testing
- `php -l admin/login.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686569c117188332b41aa718288ba625