### PR TITLE
Add configurable MercadoPago link

### DIFF
--- a/admin/configuracion.php
+++ b/admin/configuracion.php
@@ -13,12 +13,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     set_setting('mp_public_key', $_POST['mp_public_key'] ?? '');
     set_setting('mp_access_token', $_POST['mp_access_token'] ?? '');
     set_setting('webhook_secret', $_POST['webhook_secret'] ?? '');
+    set_setting('mp_subscription_link', $_POST['mp_subscription_link'] ?? '');
     $msg = 'Configuración guardada';
 }
 
 $public_key = get_setting('mp_public_key');
 $access_token = get_setting('mp_access_token');
 $webhook_secret = get_setting('webhook_secret');
+$mp_subscription_link = get_setting('mp_subscription_link');
 ?>
 <h2>Configuración de Integraciones</h2>
 <?php if (!empty($msg)) echo "<p style='color:green;'>$msg</p>"; ?>
@@ -29,6 +31,8 @@ $webhook_secret = get_setting('webhook_secret');
     <input type="text" name="mp_access_token" value="<?= htmlspecialchars($access_token) ?>">
     <label>Clave Webhook</label>
     <input type="text" name="webhook_secret" value="<?= htmlspecialchars($webhook_secret) ?>">
+    <label>Enlace de Suscripción de MercadoPago</label>
+    <input type="text" name="mp_subscription_link" value="<?= htmlspecialchars($mp_subscription_link) ?>">
     <button type="submit">Guardar</button>
 </form>
 <?php require_once 'includes/footer.php'; ?>

--- a/admin/registro_desde_wp.php
+++ b/admin/registro_desde_wp.php
@@ -4,6 +4,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 require_once __DIR__ . '/includes/config.php';
+require_once __DIR__ . '/includes/settings.php';
 
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $nombre = $_POST['nombre'] ?? '';
@@ -39,8 +40,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $stmt->close();
 
     $referencia = "usuario_" . $user_id;
-    $plan_id = "2c938084977bbd9301977bcadb8b0000";
-    $url_mp = "https://www.mercadopago.com.ar/subscriptions/checkout?preapproval_plan_id={$plan_id}&external_reference={$referencia}";
+    $base_link = get_setting('mp_subscription_link');
+    if (!$base_link) {
+        $plan_id = "2c938084977bbd9301977bcadb8b0000";
+        $base_link = "https://www.mercadopago.com.ar/subscriptions/checkout?preapproval_plan_id={$plan_id}";
+    }
+    $url_mp = $base_link . "&external_reference={$referencia}";
     header("Location: $url_mp");
     exit;
 }

--- a/admin/registro_desde_wp.php
+++ b/admin/registro_desde_wp.php
@@ -42,7 +42,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $referencia = "usuario_" . $user_id;
     $base_link = get_setting('mp_subscription_link');
     if (!$base_link) {
-        $plan_id = "2c938084977bbd9301977bcadb8b0000";
+        $plan_id = "2c93808497c876110197ccac22f2022c";
         $base_link = "https://www.mercadopago.com.ar/subscriptions/checkout?preapproval_plan_id={$plan_id}";
     }
     $url_mp = $base_link . "&external_reference={$referencia}";


### PR DESCRIPTION
## Summary
- allow configuring MercadoPago subscription link in Admin
- use the configured link when redirecting users to subscription page

## Testing
- `php` commands not available

------
https://chatgpt.com/codex/tasks/task_e_6865cec903288332884ef4e219b26f55