### PR TITLE
Fix line spacing in thanks preview

### DIFF
--- a/public/thanks.php
+++ b/public/thanks.php
@@ -204,6 +204,7 @@ header {
             white-space: nowrap;
             width: 100%;
             margin-bottom: 5px;
+            line-height: 1;
         }
         .modelo img {
             width: 100%;


### PR DESCRIPTION
## Summary
- align `thanks.php` preview line spacing with the order preview by setting `line-height` to `1`

## Testing
- `php -l public/thanks.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edb86154c83329dc2aea15cad354d